### PR TITLE
clarity in background with loading spinner

### DIFF
--- a/zedd-app/src/ClarityState.ts
+++ b/zedd-app/src/ClarityState.ts
@@ -20,7 +20,7 @@ export interface ClarityTask extends ZeddClarityTask {
 
 export enum ClarityActionType {
   SubmitTimesheet,
-  ImportTasks
+  ImportTasks,
 }
 
 export class ClarityState {
@@ -41,13 +41,13 @@ export class ClarityState {
   public resourceName: string | undefined
 
   @observable
-  public error: string = ""
+  public error = ''
 
   @observable
-  public success: boolean = false
+  public success = false
 
   @observable
-  public actionType: ClarityActionType 
+  public actionType: ClarityActionType
 
   @observable
   private _currentlyImportingTasks = false
@@ -99,9 +99,7 @@ export class ClarityState {
     this.actionType = ClarityActionType.SubmitTimesheet
     console.log('exporting timesheets', clarityExport)
     try {
-      this._currentlyImportingTasks = true
-      this.error = ""
-      this.success = false
+      this.clearClarityState()
       await fillClarity(this.nikuLink, clarityExport, submitTimesheets, this.resourceName, {
         headless: this.chromeHeadless,
         chromeExe: this.chromeExe,
@@ -164,6 +162,12 @@ export class ClarityState {
     return this.resolveTask(intId) !== undefined
   }
 
+  private clearClarityState() {
+    this._currentlyImportingTasks = true
+    this.error = ''
+    this.success = false
+  }
+
   private async importClarityTasks(
     excludeProject: (projectName: string) => boolean,
     notifyProject?: (p: ZeddClarityProject) => void,
@@ -173,16 +177,14 @@ export class ClarityState {
       throw new Error('Already importing')
     }
     try {
-      this._currentlyImportingTasks = true
-      this.error = ""
-      this.success = false
+      this.clearClarityState()
       const projectInfos = await getProjectInfo(
         this.nikuLink,
         {
           downloadDir: path.join(this.clarityDir, 'dl'),
           chromeExe: this.chromeExe,
           chromedriverExe: this.chromedriverExe,
-          headless: this.chromeHeadless
+          headless: this.chromeHeadless,
         },
         excludeProject,
         notifyProject,
@@ -196,7 +198,7 @@ export class ClarityState {
               projectName,
               projectIntId,
             },
-            (task as unknown) as ClarityTask,
+            task as unknown as ClarityTask,
           ),
         ),
       )

--- a/zedd-app/src/ClarityState.ts
+++ b/zedd-app/src/ClarityState.ts
@@ -25,6 +25,8 @@ export class ClarityState {
 
   public chromedriverExe: string
 
+  public chromeHeadless: boolean
+
   /**
    * The name of the "clarity resource" you are filling out
    * timesheets for, i.e. yourself. this is only required
@@ -84,7 +86,7 @@ export class ClarityState {
     try {
       this._currentlyImportingTasks = true
       await fillClarity(this.nikuLink, clarityExport, submitTimesheets, this.resourceName, {
-        headless: false,
+        headless: this.chromeHeadless,
         chromeExe: this.chromeExe,
         chromedriverExe: this.chromedriverExe,
       })
@@ -159,6 +161,7 @@ export class ClarityState {
           downloadDir: path.join(this.clarityDir, 'dl'),
           chromeExe: this.chromeExe,
           chromedriverExe: this.chromedriverExe,
+          headless: this.chromeHeadless
         },
         excludeProject,
         notifyProject,

--- a/zedd-app/src/ZeddSettings.ts
+++ b/zedd-app/src/ZeddSettings.ts
@@ -67,8 +67,8 @@ export class ZeddSettings {
    */
   @observable
   @serializable
-  public chromeHeadless: boolean = true
-  
+  public chromeHeadless = true
+
   /**
    * mininum user idle time in minutes which counts as "user is away"
    */

--- a/zedd-app/src/ZeddSettings.ts
+++ b/zedd-app/src/ZeddSettings.ts
@@ -63,6 +63,13 @@ export class ZeddSettings {
   public nikuLink = ''
 
   /**
+   * Open Chrome / Selenium in headless mode (background)
+   */
+  @observable
+  @serializable
+  public chromeHeadless: boolean = true
+  
+  /**
    * mininum user idle time in minutes which counts as "user is away"
    */
   @observable

--- a/zedd-app/src/components/AppBody.tsx
+++ b/zedd-app/src/components/AppBody.tsx
@@ -430,7 +430,10 @@ export const AppBody = observer(
             clarityState={clarityState}
             submitTimesheets={state.submitTimesheets}
             onChangeSubmitTimesheets={(x) => (state.submitTimesheets = x)}
-            errorHandler={(error) => state.addMessage(error.message)}
+            errorHandler={(error) => {
+              clarityState.error = error.message
+              state.addMessage(error.message)
+            }}
             calculateTargetHours={(interval) => state.calcTargetHours(interval)}
           />
         </ErrorBoundary>

--- a/zedd-app/src/components/ClarityView.tsx
+++ b/zedd-app/src/components/ClarityView.tsx
@@ -36,7 +36,9 @@ import { useState } from 'react'
 import { ClarityExportFormat } from 'zedd-clarity'
 
 import { TimeSlice, validDate } from '../AppState'
-import { ClarityState } from '../ClarityState'
+import { ClarityState, ClarityActionType } from '../ClarityState'
+import { LoadingSpinner } from './LoadingSpinner'
+
 import { isoDayStr, omap, splitIntervalIntoCalendarDays, sum } from '../util'
 
 const roundToNearest = (x: number, toNearest: number) => Math.round(x / toNearest) * toNearest
@@ -402,10 +404,13 @@ export const ClarityView = observer((props: ClarityViewProps) => {
         </tfoot>
       </CardContent>
       <CardActions style={{ flexDirection: 'row-reverse' }}>
+        {clarityState.actionType === ClarityActionType.SubmitTimesheet &&
+          <LoadingSpinner loading={clarityState.currentlyImportingTasks} error={clarityState.error !== ""} success={clarityState.success} />
+        }
         <Button
           disabled={clarityState.currentlyImportingTasks}
           variant='contained'
-          onClick={() => {
+          onClick={() => 
             clarityState
               .export(
                 omap(clarityExport, (workEntries) =>
@@ -414,7 +419,7 @@ export const ClarityView = observer((props: ClarityViewProps) => {
                 submitTimesheets,
               )
               .catch(errorHandler)
-          }}
+          }
           endIcon={<SendIcon />}
         >
           Clarity!

--- a/zedd-app/src/components/ClarityView.tsx
+++ b/zedd-app/src/components/ClarityView.tsx
@@ -404,13 +404,17 @@ export const ClarityView = observer((props: ClarityViewProps) => {
         </tfoot>
       </CardContent>
       <CardActions style={{ flexDirection: 'row-reverse' }}>
-        {clarityState.actionType === ClarityActionType.SubmitTimesheet &&
-          <LoadingSpinner loading={clarityState.currentlyImportingTasks} error={clarityState.error !== ""} success={clarityState.success} />
-        }
+        {clarityState.actionType === ClarityActionType.SubmitTimesheet && (
+          <LoadingSpinner
+            loading={clarityState.currentlyImportingTasks}
+            error={clarityState.error !== ''}
+            success={clarityState.success}
+          />
+        )}
         <Button
           disabled={clarityState.currentlyImportingTasks}
           variant='contained'
-          onClick={() => 
+          onClick={() =>
             clarityState
               .export(
                 omap(clarityExport, (workEntries) =>

--- a/zedd-app/src/components/LoadingSpinner.tsx
+++ b/zedd-app/src/components/LoadingSpinner.tsx
@@ -1,35 +1,28 @@
-import * as React from 'react';
-import CircularProgress, {
-  CircularProgressProps,
-} from '@mui/material/CircularProgress';
-import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
-import Fab from '@mui/material/Fab';
-import { green, red } from '@mui/material/colors';
-import CloseIcon from '@mui/icons-material/Close';
-import CheckIcon from '@mui/icons-material/Check';
+import * as React from 'react'
+import CircularProgress, { CircularProgressProps } from '@mui/material/CircularProgress'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+import { green, red } from '@mui/material/colors'
+import { Close as CloseIcon, Check as CheckIcon } from '@mui/icons-material'
 
 interface ILoadingSpinner extends CircularProgressProps {
-  loading: boolean;
-  value?: number;
-  success: boolean;
-  error: boolean;
+  loading: boolean
+  value?: number
+  success: boolean
+  error: boolean
 }
 
-export function LoadingSpinner(
-  props: ILoadingSpinner
-) {
-
-  if(!props.success && !props.error && !props.loading) {
-    return null;
+export function LoadingSpinner(props: ILoadingSpinner) {
+  if (!props.success && !props.error && !props.loading) {
+    return null
   }
 
   return (
     <Box sx={{ position: 'relative', display: 'inline-flex' }}>
       {props.loading && (
         <>
-          <CircularProgress color="warning" thickness={5} {...props} />
-          {props.value && 
+          <CircularProgress color='warning' thickness={5} {...props} />
+          {props.value && (
             <Box
               sx={{
                 top: 0,
@@ -42,17 +35,15 @@ export function LoadingSpinner(
                 justifyContent: 'center',
               }}
             >
-              <Typography
-                variant="caption"
-                component="div"
-                color="text.secondary"
-              >{`${Math.round(props.value)}%`}</Typography>
+              <Typography variant='caption' component='div' color='text.secondary'>
+                {`${Math.round(props.value)}%`}
+              </Typography>
             </Box>
-          }
+          )}
         </>
       )}
-      {props.success && <CheckIcon sx={{color: green[700]}} />}
-      {props.error && <CloseIcon sx={{color: red[700]}} />}
+      {props.success && <CheckIcon sx={{ color: green[700] }} />}
+      {props.error && <CloseIcon sx={{ color: red[700] }} />}
     </Box>
-  );
+  )
 }

--- a/zedd-app/src/components/LoadingSpinner.tsx
+++ b/zedd-app/src/components/LoadingSpinner.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import CircularProgress, {
+  CircularProgressProps,
+} from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Fab from '@mui/material/Fab';
+import { green, red } from '@mui/material/colors';
+import CloseIcon from '@mui/icons-material/Close';
+import CheckIcon from '@mui/icons-material/Check';
+
+interface ILoadingSpinner extends CircularProgressProps {
+  loading: boolean;
+  value?: number;
+  success: boolean;
+  error: boolean;
+}
+
+export function LoadingSpinner(
+  props: ILoadingSpinner
+) {
+
+  if(!props.success && !props.error && !props.loading) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+      {props.loading && (
+        <>
+          <CircularProgress color="warning" thickness={5} {...props} />
+          {props.value && 
+            <Box
+              sx={{
+                top: 0,
+                left: 0,
+                bottom: 0,
+                right: 0,
+                position: 'absolute',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography
+                variant="caption"
+                component="div"
+                color="text.secondary"
+              >{`${Math.round(props.value)}%`}</Typography>
+            </Box>
+          }
+        </>
+      )}
+      {props.success && <CheckIcon sx={{color: green[700]}} />}
+      {props.error && <CloseIcon sx={{color: red[700]}} />}
+    </Box>
+  );
+}

--- a/zedd-app/src/components/SettingsDialog.tsx
+++ b/zedd-app/src/components/SettingsDialog.tsx
@@ -219,6 +219,19 @@ export const SettingsDialog = observer(
                 }}
               />
             </Grid>
+
+            <Grid item xs={4}>
+              <FormLabel>Open Chrome in</FormLabel>
+            </Grid>
+            <Grid item xs={8} component={'label'}>
+              Foreground
+              <Switch
+                checked={!!settings.chromeHeadless}
+                onChange={(_, checked) => (settings.chromeHeadless = !!checked)}
+              />
+              Background
+            </Grid>
+
             <Grid item xs={4}>
               <FormLabel>Location (for public holidays)</FormLabel>
             </Grid>

--- a/zedd-app/src/components/TaskEditor.tsx
+++ b/zedd-app/src/components/TaskEditor.tsx
@@ -45,14 +45,15 @@ export const TaskEditor = observer(
             'ALL' === which ? 'ALL' : 'NEW' === which ? 'NEW' : [which],
             (info) => state.addMessage(info, 'info', 2000),
           )
-          .catch((e) =>
+          .catch((e) => {
+            clarityState.error = e.message
             state.addMessage(
               e.message +
                 (e instanceof NikuUrlInvalidError
                   ? 'Check zeddConfig.nikuLink and reload config.'
                   : ''),
-            ),
-          ),
+            )
+          }),
         [clarityState, state],
     )
 

--- a/zedd-app/src/components/TaskEditor.tsx
+++ b/zedd-app/src/components/TaskEditor.tsx
@@ -12,8 +12,9 @@ import { useCallback, useState, useRef } from 'react'
 import { NikuUrlInvalidError } from 'zedd-clarity'
 
 import { AppState, Task } from '../AppState'
-import { ClarityState } from '../ClarityState'
+import { ClarityState, ClarityActionType } from '../ClarityState'
 import { ClarityTaskSelect } from './ClarityTaskSelect'
+import { LoadingSpinner } from './LoadingSpinner'
 import { TaskSelect } from './TaskSelect'
 
 interface TaskEditorProps {
@@ -52,7 +53,7 @@ export const TaskEditor = observer(
                   : ''),
             ),
           ),
-      [clarityState, state],
+        [clarityState, state],
     )
 
     const [popperOpen, setPopperOpen] = useState(false)
@@ -133,10 +134,15 @@ export const TaskEditor = observer(
           >
             <Button
               variant='text'
-              onClick={() => setPopperOpen(!popperOpen)}
+              onClick={() => !clarityState.currentlyImportingTasks && setPopperOpen(!popperOpen)}
               style={{ width: '100%' }}
               ref={anchorRef}
-              endIcon={<ImportIcon />}
+              endIcon={<>
+                <ImportIcon />
+                {clarityState.actionType === ClarityActionType.ImportTasks &&
+                  <LoadingSpinner loading={clarityState.currentlyImportingTasks} error={clarityState.error !== ""} success={clarityState.success} />
+                }
+              </>}
             >
               Import
             </Button>

--- a/zedd-app/src/components/TaskEditor.tsx
+++ b/zedd-app/src/components/TaskEditor.tsx
@@ -54,7 +54,7 @@ export const TaskEditor = observer(
                   : ''),
             )
           }),
-        [clarityState, state],
+      [clarityState, state],
     )
 
     const [popperOpen, setPopperOpen] = useState(false)
@@ -138,12 +138,18 @@ export const TaskEditor = observer(
               onClick={() => !clarityState.currentlyImportingTasks && setPopperOpen(!popperOpen)}
               style={{ width: '100%' }}
               ref={anchorRef}
-              endIcon={<>
-                <ImportIcon />
-                {clarityState.actionType === ClarityActionType.ImportTasks &&
-                  <LoadingSpinner loading={clarityState.currentlyImportingTasks} error={clarityState.error !== ""} success={clarityState.success} />
-                }
-              </>}
+              endIcon={
+                <>
+                  <ImportIcon />
+                  {clarityState.actionType === ClarityActionType.ImportTasks && (
+                    <LoadingSpinner
+                      loading={clarityState.currentlyImportingTasks}
+                      error={clarityState.error !== ''}
+                      success={clarityState.success}
+                    />
+                  )}
+                </>
+              }
             >
               Import
             </Button>

--- a/zedd-app/src/renderer.ts
+++ b/zedd-app/src/renderer.ts
@@ -77,10 +77,10 @@ function quit() {
 
 function setupAutoUpdater(state: AppState, config: ZeddSettings) {
   if (global.isDev)
-    return () => {
-      /* do nothing */
-    }
-
+  return () => {
+    /* do nothing */
+  }
+  
   autoUpdater.setFeedURL({
     url: `${config.updateServer}/update/${process.platform}/${app.getVersion()}`,
   })
@@ -129,6 +129,7 @@ async function setup() {
   clarityState.init()
   autorun(() => {
     clarityState.nikuLink = config.nikuLink
+    clarityState.chromeHeadless = config.chromeHeadless
     clarityState.resourceName = config.clarityResourceName
   })
 

--- a/zedd-app/src/renderer.ts
+++ b/zedd-app/src/renderer.ts
@@ -77,10 +77,10 @@ function quit() {
 
 function setupAutoUpdater(state: AppState, config: ZeddSettings) {
   if (global.isDev)
-  return () => {
-    /* do nothing */
-  }
-  
+    return () => {
+      /* do nothing */
+    }
+
   autoUpdater.setFeedURL({
     url: `${config.updateServer}/update/${process.platform}/${app.getVersion()}`,
   })
@@ -479,7 +479,7 @@ async function setup() {
   window.addEventListener('beforeunload', cleanup)
 
   return {
-    cleanup: cleanup = () => {
+    cleanup: (cleanup = () => {
       console.log('setup().cleanup')
       clearInterval(saveInterval)
       clearInterval(lastActionInterval)
@@ -493,7 +493,7 @@ async function setup() {
       cleanupHoverModeAutorun()
       currentWindowEvents.forEach(([x, y]) => currentWindow.removeListener(x as any, y))
       window.removeEventListener('beforeunload', cleanup)
-    },
+    }),
     renderDOM: () => {
       ReactDOM.render(
         React.createElement(AppGui, {


### PR DESCRIPTION
The Selenium Browser is now started in the background by default. With a configuration in the config, it can still be run in the foreground. During the execution the user gets visual feedback via a spinner and as soon as the process was successful a green tick or in case of an error a red cross is displayed (incl. error message). 